### PR TITLE
Remove "query" from the keyword list.

### DIFF
--- a/chapters/02-structure-of-an-erlang-program.tex
+++ b/chapters/02-structure-of-an-erlang-program.tex
@@ -213,5 +213,5 @@ The following are reserved words in Erlang:
 
 \begin{erlang}
 after and andalso band begin bnot bor bsl bsr bxor case catch cond
-div end fun if let not of or orelse query receive rem try when xor
+div end fun if let not of or orelse receive rem try when xor
 \end{erlang}


### PR DESCRIPTION
"query" is no longer a keyword (since R16B).
See erlang/otp@0dc3a29
