### PR TITLE
Added back Anonymous funs

### DIFF
--- a/chapters/05-functions.tex
+++ b/chapters/05-functions.tex
@@ -575,10 +575,7 @@ Fun2 = fun (X) when X>=1000 -> big; (X) -> small end.
 Fun2(2000)      % big
 \end{erlang}
 
-Anonymous \texttt{funs}: When a \texttt{fun} is anonymous, i.e.~there is no function name in the 
-definition of the \texttt{fun}, the definition of a recursive \texttt{fun} has to be
-done in two steps.  This example shows how to define an anonymous \texttt{fun} 
-\texttt{sum(List)} (see section \ref{datatypes:list}) as a \texttt{fun}.
+Anonymous \texttt{funs}: When a \texttt{fun} is anonymous, i.e.~there is no function name in the definition of the \texttt{fun}, the definition of a recursive \texttt{fun} has to be done in two steps. This example shows how to define an anonymous \texttt{fun} \texttt{sum(List)} (see section \ref{datatypes:list}) as an anonymous \texttt{fun}.
 
 \begin{erlang}
 Sum1 = fun ([], _Foo) -> 0;([H|T], Foo) -> H + Foo(T, Foo) end.


### PR DESCRIPTION
Added back Anonymous funs section, since both Anonymous funs  and Named funs are both valid for R17.0
Also corrected the  ending bit of the fun's section which did not make sense after the previous commit 
