### PR TITLE
miss a .git extension on page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <section id="downloads" class="clearfix">
           <a href="https://github.com/esl/erlang-handbook/zipball/master" id="download-zip" class="button"><span>Download .zip</span></a>
           <a href="https://github.com/esl/erlang-handbook/tarball/master" id="download-tar-gz" class="button"><span>Download .tar.gz</span></a>
-          <a href="https://github.com/esl/erlang-handbook" id="view-on-github" class="button"><span>View on GitHub</span></a>
+          <a href="https://github.com/esl/erlang-handbook.git" id="view-on-github" class="button"><span>View on GitHub</span></a>
         </section>
 
         <hr>


### PR DESCRIPTION
The references url miss .git to reference a git repo